### PR TITLE
Settings for the fontsize

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -18,6 +18,22 @@ use libhandy::ViewSwitcherBarBuilder;
 use relm::{Relm, StreamHandle, Widget};
 use relm_derive::{widget, Msg};
 
+/// The ration between the fonts of the title and the channel/date.
+pub const FONT_RATIO: f32 = 2.0 / 3.0;
+
+pub fn get_font_size() -> i32 {
+    gtk::Settings::get_default()
+        .unwrap()
+        .get_property_gtk_font_name()
+        .unwrap_or(" ".into())
+        .to_string()
+        .split(" ")
+        .last()
+        .unwrap_or("")
+        .parse::<i32>()
+        .unwrap_or(12)
+}
+
 #[derive(Msg)]
 pub enum AppMsg {
     Loading(bool),

--- a/src/gui/feed/feed_item.rs
+++ b/src/gui/feed/feed_item.rs
@@ -1,6 +1,7 @@
 use crate::gui::app::AppMsg;
 use crate::gui::feed::date_label::DateLabel;
 use crate::gui::feed::thumbnail::{Thumbnail, ThumbnailMsg};
+use crate::gui::{get_font_size, FONT_RATIO};
 use crate::youtube_feed::Entry;
 
 use std::thread;
@@ -10,9 +11,6 @@ use gtk::{Align, ImageExt, Justification, Orientation, PackType};
 use pango::{AttrList, Attribute, EllipsizeMode, WrapMode};
 use relm::{Relm, StreamHandle, Widget};
 use relm_derive::{widget, Msg};
-
-/// The ration between the fonts of the title and the channel/date.
-const FONT_RATIO: f32 = 2.0 / 3.0;
 
 #[derive(Msg)]
 pub enum FeedListItemMsg {
@@ -94,16 +92,7 @@ impl Widget for FeedListItem {
             PackType::Start,
         );
 
-        let font_size = gtk::Settings::get_default()
-            .unwrap()
-            .get_property_gtk_font_name()
-            .unwrap()
-            .to_string()
-            .split(" ")
-            .last()
-            .unwrap_or("")
-            .parse::<i32>()
-            .unwrap_or(12);
+        let font_size = get_font_size();
 
         let title_attr_list = AttrList::new();
         title_attr_list.insert(Attribute::new_size(font_size * pango::SCALE).unwrap());

--- a/src/gui/feed/feed_item.rs
+++ b/src/gui/feed/feed_item.rs
@@ -11,6 +11,9 @@ use pango::{AttrList, Attribute, EllipsizeMode, WrapMode};
 use relm::{Relm, StreamHandle, Widget};
 use relm_derive::{widget, Msg};
 
+/// The ration between the fonts of the title and the channel/date.
+const FONT_RATIO: f32 = 2.0 / 3.0;
+
 #[derive(Msg)]
 pub enum FeedListItemMsg {
     SetImage,
@@ -91,14 +94,27 @@ impl Widget for FeedListItem {
             PackType::Start,
         );
 
+        let font_size = gtk::Settings::get_default()
+            .unwrap()
+            .get_property_gtk_font_name()
+            .unwrap()
+            .to_string()
+            .split(" ")
+            .last()
+            .unwrap_or("")
+            .parse::<i32>()
+            .unwrap_or(12);
+
         let title_attr_list = AttrList::new();
-        title_attr_list.insert(Attribute::new_size(12 * pango::SCALE).unwrap());
+        title_attr_list.insert(Attribute::new_size(font_size * pango::SCALE).unwrap());
         self.widgets
             .label_title
             .set_attributes(Some(&title_attr_list));
 
         let author_attr_list = AttrList::new();
-        author_attr_list.insert(Attribute::new_size(8 * pango::SCALE).unwrap());
+        author_attr_list.insert(
+            Attribute::new_size((FONT_RATIO * (font_size * pango::SCALE) as f32) as i32).unwrap(),
+        );
         self.widgets
             .label_author
             .set_attributes(Some(&author_attr_list));

--- a/src/gui/feed/feed_item.rs
+++ b/src/gui/feed/feed_item.rs
@@ -123,6 +123,7 @@ impl Widget for FeedListItem {
             #[name="box_content"]
             gtk::Box {
                 orientation: Orientation::Horizontal,
+                spacing: 8,
 
                 #[name="playing"]
                 gtk::Image {
@@ -135,6 +136,7 @@ impl Widget for FeedListItem {
                 #[name="box_info"]
                 gtk::Box {
                     orientation: Orientation::Vertical,
+                    spacing: 4,
 
                     #[name="label_title"]
                     gtk::Label {

--- a/src/gui/filter/filter_item.rs
+++ b/src/gui/filter/filter_item.rs
@@ -1,5 +1,6 @@
 use crate::filter::EntryFilter;
 use crate::gui::app::AppMsg;
+use crate::gui::{get_font_size, FONT_RATIO};
 
 use gtk::prelude::*;
 use gtk::Align;
@@ -38,14 +39,17 @@ impl Widget for FilterItem {
     }
 
     fn init_view(&mut self) {
+        let font_size = get_font_size();
         let title_attr_list = AttrList::new();
-        title_attr_list.insert(Attribute::new_size(15 * pango::SCALE).unwrap());
+        title_attr_list.insert(Attribute::new_size(font_size * pango::SCALE).unwrap());
         self.widgets
             .label_title
             .set_attributes(Some(&title_attr_list));
 
         let channel_attr_list = AttrList::new();
-        channel_attr_list.insert(Attribute::new_size(12 * pango::SCALE).unwrap());
+        channel_attr_list.insert(
+            Attribute::new_size((FONT_RATIO * (font_size * pango::SCALE) as f32) as i32).unwrap(),
+        );
         self.widgets
             .label_channel
             .set_attributes(Some(&channel_attr_list));

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -7,3 +7,4 @@ mod lazy_list;
 mod subscriptions;
 
 pub use app::Win;
+use app::{get_font_size, FONT_RATIO};

--- a/src/gui/subscriptions/subscription_item.rs
+++ b/src/gui/subscriptions/subscription_item.rs
@@ -1,4 +1,5 @@
 use crate::gui::app::AppMsg;
+use crate::gui::{get_font_size, FONT_RATIO};
 use crate::subscriptions::Channel;
 
 use gtk::prelude::*;
@@ -41,14 +42,17 @@ impl Widget for SubscriptionItem {
     }
 
     fn init_view(&mut self) {
+        let font_size = get_font_size();
         let name_attr_list = AttrList::new();
-        name_attr_list.insert(Attribute::new_size(15 * pango::SCALE).unwrap());
+        name_attr_list.insert(Attribute::new_size(font_size * pango::SCALE).unwrap());
         self.widgets
             .label_name
             .set_attributes(Some(&name_attr_list));
 
         let id_attr_list = AttrList::new();
-        id_attr_list.insert(Attribute::new_size(7 * pango::SCALE).unwrap());
+        id_attr_list.insert(
+            Attribute::new_size((FONT_RATIO * (font_size * pango::SCALE) as f32) as i32).unwrap(),
+        );
         self.widgets.label_id.set_attributes(Some(&id_attr_list));
     }
 

--- a/src/gui/subscriptions/subscriptions_page.rs
+++ b/src/gui/subscriptions/subscriptions_page.rs
@@ -106,7 +106,7 @@ impl Widget for SubscriptionsPage {
 
         thread::spawn(move || {
             sender
-                .send(Channel::from_name(&channel_name))
+                .send(Channel::from_id_or_name(&channel_name))
                 .expect("Could not send channel");
         });
     }
@@ -119,7 +119,7 @@ impl Widget for SubscriptionsPage {
                 visible: self.model.add_subscription_visible,
                 #[name="channel_name_entry"]
                 gtk::Entry {
-                    placeholder_text: Some("Channel Name")
+                    placeholder_text: Some("Channel Name or ID")
                 },
                 gtk::Button {
                     clicked => SubscriptionsPageMsg::AddSubscription,

--- a/src/subscriptions/channel.rs
+++ b/src/subscriptions/channel.rs
@@ -60,7 +60,7 @@ impl Channel {
     /// Will try to download the channels youtube page and get the id.
     #[tokio::main]
     pub async fn from_name(name: &str) -> Result<Self, Error> {
-        let url = format!("https://www.youtube.com/user/{}", name);
+        let url = format!("https://www.youtube.com/c/{}/featured", name);
         let content: Result<String, Error> = async {
             let response = reqwest::get(&url).await;
 

--- a/src/subscriptions/channel.rs
+++ b/src/subscriptions/channel.rs
@@ -56,10 +56,22 @@ impl Channel {
         }
     }
 
+    /// Try to create a channel from a given `&str`, that may be a id or name.
+    /// It first tries to check if it is a valid id, otherwise it will try to interpret
+    /// it as a channel name.
+    #[tokio::main]
+    pub async fn from_id_or_name(id_or_name: &str) -> Result<Self, Error> {
+        let from_id = Channel::new(id_or_name);
+        if from_id.get_feed_no_main().await.is_ok() {
+            Ok(from_id)
+        } else {
+            Channel::from_name(id_or_name).await
+        }
+    }
+
     /// Cretes a new channel from the given name.
     /// Will try to download the channels youtube page and get the id.
-    #[tokio::main]
-    pub async fn from_name(name: &str) -> Result<Self, Error> {
+    async fn from_name(name: &str) -> Result<Self, Error> {
         let url = format!("https://www.youtube.com/c/{}/featured", name);
         let content: Result<String, Error> = async {
             let response = reqwest::get(&url).await;
@@ -108,6 +120,11 @@ impl Channel {
     /// This may be because youtube changed the feed site.
     #[tokio::main]
     pub async fn get_feed(&self) -> Result<Feed, Error> {
+        self.get_feed_no_main().await
+    }
+
+    /// Get the feed without needing `#[tokio::main]`.
+    async fn get_feed_no_main(&self) -> Result<Feed, Error> {
         let url = FEED_URL.to_string() + &self.id;
 
         let content: Result<String, Error> = async {


### PR DESCRIPTION
Note that to change the font size for wayland, any `settings.ini` cannot be used.
See [this wiki](https://github.com/swaywm/sway/wiki/GTK-3-settings-on-Wayland) for a explanation.
To change the font size, use `gsettings set org.gnome.desktop.interface font-name "Cantarell 11"`.

Closes #2 