### PR TITLE
Added AppImage for amd64

### DIFF
--- a/AppImage/AppImageBuilder_amd64.yml
+++ b/AppImage/AppImageBuilder_amd64.yml
@@ -1,0 +1,62 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+
+script: 
+  - rm -rf AppDir | true
+  - mkdir -p AppDir/usr/bin
+  - mkdir -p AppDir/usr/share/icons/16x16
+  - mkdir -p AppDir/usr/share/metainfo
+  - cp ../tubefeeder.desktop AppDir/de.schmidhuberj.tubefeeder.desktop
+  - cp ../tubefeeder.png AppDir/usr/share/icons/16x16
+  - cp ../target/x86_64-unknown-linux-gnu/release/tubefeeder AppDir/usr/bin/
+  - cp de.schmidhuberj.tubefeeder.appdata.xml AppDir/usr/share/metainfo/ 
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: de.schmidhuberj.tubefeeder
+    name: Tubefeeder
+    icon: tubefeeder
+    version: latest
+    exec: usr/bin/tubefeeder
+    exec_args: $@
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb http://archive.ubuntu.com/ubuntu groovy main universe'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920D1991BC93C'
+    include: 
+      - libhandy-1-0
+      - gnome-settings-daemon
+      - librsvg2-common
+    exclude:
+      - adwaita-icon-theme
+      - humanity-icon-theme
+      - libice6
+      - libnss-nisplus
+      - libnss-nis
+      - libasound2
+      - libthai
+      - libcom-err2
+      - libexpat1
+      - libgcc-s1
+      - libgpg-error0
+      - libp11-kit0
+      - libsm6
+      - libuuid1
+      - zlib1g
+      - libgmp10
+
+  files:
+    include: []
+    exclude:
+    - usr/share/man
+    - usr/share/doc/*/README.*
+    - usr/share/doc/*/changelog.*
+    - usr/share/doc/*/NEWS.*
+    - usr/share/doc/*/TODO.*
+
+AppImage:
+  arch: x86_64
+  update-information: guess
+  sign-key: None

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
 image = "tubefeeder:latest"
+
+[target.x86_64-unknown-linux-gnu]
+image = "tubefeeder/amd64:latest"

--- a/docker/Dockerfile_amd64
+++ b/docker/Dockerfile_amd64
@@ -1,0 +1,53 @@
+# This file is originally from https://github.com/rust-embedded/cross but modified to work with Ubuntu 20.10, gtk and libhandy.
+
+FROM ubuntu:20.10
+
+RUN apt-get update && apt-get install --assume-yes wget git
+
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/cmake.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/common.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/lib.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/xargo.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/qemu.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/dropbear.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/linux-image.sh
+RUN wget https://raw.githubusercontent.com/rust-embedded/cross/master/docker/linux-runner
+
+RUN chmod +x ./cmake.sh
+RUN chmod +x ./common.sh
+RUN chmod +x ./lib.sh
+RUN chmod +x ./xargo.sh
+RUN chmod +x ./qemu.sh
+RUN chmod +x ./dropbear.sh
+RUN chmod +x ./linux-image.sh
+RUN chmod +x ./linux-runner
+
+COPY linux-image.sh.diff /
+RUN git apply linux-image.sh.diff
+
+RUN /common.sh
+
+RUN /cmake.sh
+
+RUN /xargo.sh
+
+RUN apt-get install --assume-yes --no-install-recommends \
+    libc6-dev-amd64-cross
+
+RUN /qemu.sh x86_64 softmmu
+
+RUN /dropbear.sh
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+
+RUN apt-get install --assume-yes libc6 -o APT::Immediate-Configure=0
+
+RUN apt-get install --assume-yes libgtk-3-dev x11proto-dev
+
+ENV PKG_CONFIG_LIBDIR=/usr/local/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig/ \
+    PKG_CONFIG_ALLOW_CROSS=1
+
+RUN apt-get install --assume-yes libhandy-1-0 libhandy-1-dev


### PR DESCRIPTION
I think I have made a working AppImage for arm64.
I cannot include the file in this text, so you have to compile it yourself to try it.

Compilation steps (docker, rust, cross, appimage-builder have to be installed)

- `docker build -t tubefeeder/amd64 docker -f  docker/Dockerfile_amd64`
- `cross build --target=x86_64-unknown-linux-gnu --release`
- `cd AppImage`
- `appimage-builder --recipe AppImageBuilder_amd64.yml`
- `./Tubefeeder-latest-x86_64.AppImage`

Please let me know when you cannot compile it yourself, we will find a way to share the compiled AppImage.

Closes #13 

